### PR TITLE
Allow angular 1.3 as a dependency when using Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,9 +6,9 @@
     "dist/ngToast.css"
   ],
   "dependencies": {
-    "angular": "~1.2.15",
-    "angular-animate": "~1.2.17",
-    "angular-sanitize": "~1.2.15"
+    "angular": ">=1.2.15 <1.4.0",
+    "angular-animate": ">=1.2.17 <1.4.0",
+    "angular-sanitize": ">=1.2.15 <1.4.0"
   },
   "ignore": [
       "**/.*",


### PR DESCRIPTION
It seems to work fine on Angular 1.3