### PR TITLE
Remove dupe var name that hides from parent scope

### DIFF
--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -46,7 +46,7 @@
           scope: {
             message: '='
           },
-          controller: ['$scope', 'ngToast', function($scope, ngToast) {
+          controller: ['$scope', function($scope) {
             $scope.dismiss = function() {
               ngToast.dismiss($scope.message.id);
             };


### PR DESCRIPTION
`ngToast` is injected at the directive level, so no need to also inject it on the controller (unless I'm misunderstanding something here...).  Either way, these two variable have the same name. If this needs to stay, it should at least be renamed.