### PR TITLE
Added Controller/ControllerAs/Template/TemplateUrl Property

### DIFF
--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -84,8 +84,42 @@
           }
         };
       }
-    ]);
+    ])
+    .directive('toastMessage', ['$timeout', '$compile', '$controller', '$log',
+      function($timeout, $compile, $controller, $log) {
+        return {
+          restrict: 'EA',
+          link: function (scope, $element) {
+            if(scope.message.template && !scope.message.controller) {
+              return $log.error('[ngToast] Controller is required is you want to use a custom template');
+            }
 
+            if(!scope.message.template && scope.message.controller) {
+              return $log.error('[ngToast] Template is required is you want to associating a controller with a toast');
+            }
+
+            if(!scope.message.template && !scope.message.controller) {
+              return;
+            }
+
+            if(scope.message.compileContent) {
+              return $log.error('[ngToast] `compileContent` option is incompatible with `controller`. Consider removing it.');
+            }
+
+            $element.html(_getDefaultTemplate(scope.message.template));
+            var locals = {};
+            var link = $compile($element.contents());
+
+            locals.$scope = scope;
+            locals.$element = $element;
+            $controller(scope.message.controller, locals);
+
+            link(scope);
+          }
+        };
+      }
+    ])
+  ;
 
   function _getDefaultTemplate(customContent)
   {

--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -77,6 +77,17 @@
             }
 
             if (scope.message.dismissOnClick) {
+              _bindDismissActionTo(element);
+            }
+
+            if(!scope.message.dismissOnClick && scope.message.dismissButton && scope.message.$$controller) {
+              $timeout(function() {
+                _bindDismissActionTo(element.find('button').eq(0));
+              }, 0);
+            }
+
+            ////
+            function _bindDismissActionTo(element) {
               element.bind('click', function() {
                 ngToast.dismiss(scope.message.id);
                 scope.$apply();
@@ -108,6 +119,7 @@
               return $log.error('[ngToast] `compileContent` option is incompatible with `controller`. Consider removing it.');
             }
 
+            scope.message.$$controller = true;
             $element.html(_getDefaultTemplate(scope.message.template));
             var locals = {};
             var link = $compile($element.contents());

--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -105,14 +105,16 @@
         };
       }
     ])
-    .directive('toastMessage', ['$timeout', '$compile', '$controller', '$log', '$templateRequest',
-      function($timeout, $compile, $controller, $log, $templateRequest) {
+    .directive('toastMessage', ['$timeout', '$compile', '$controller', '$log', '$http', '$templateCache',
+      function($timeout, $compile, $controller, $log, $http, $templateCache) {
         return {
           restrict: 'EA',
           priority: -400,
           link: function (scope, $element) {
             if(!scope.message.template && scope.message.templateUrl) {
-              scope.message.template = scope.message.$$promise = $templateRequest(scope.message.templateUrl);
+              scope.message.template = scope.message.$$promise = $http
+                .get(scope.message.templateUrl, { cache: $templateCache, headers: { Accept: 'text/html' }})
+                .then(function(response) { return response.data; });
             }
 
             if(scope.message.template && !scope.message.controller) {

--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -114,7 +114,11 @@
 
             locals.$scope = scope;
             locals.$element = $element;
-            $controller(scope.message.controller, locals);
+            var controller = $controller(scope.message.controller, locals);
+
+            if (scope.message.controllerAs) {
+              scope[scope.message.controllerAs] = controller;
+            }
 
             link(scope);
           }

--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -42,6 +42,7 @@
         return {
           replace: true,
           transclude: true,
+          priority: 400,
           restrict: 'EA',
           scope: {
             message: '='
@@ -89,6 +90,7 @@
       function($timeout, $compile, $controller, $log) {
         return {
           restrict: 'EA',
+          priority: -400,
           link: function (scope, $element) {
             if(scope.message.template && !scope.message.controller) {
               return $log.error('[ngToast] Controller is required is you want to use a custom template');

--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -51,18 +51,7 @@
               ngToast.dismiss($scope.message.id);
             };
           }],
-          template:
-            '<li class="ng-toast__message {{message.additionalClasses}}">' +
-              '<div class="alert alert-{{message.className}}" ' +
-                'ng-class="{\'alert-dismissible\': message.dismissButton}">' +
-                '<button type="button" class="close" ' +
-                  'ng-if="message.dismissButton" ' +
-                  'ng-bind-html="message.dismissButtonHtml" ' +
-                  'ng-click="!message.dismissOnClick && dismiss()">' +
-                '</button>' +
-                '<span ng-if="!message.compileContent" ng-transclude></span>' +
-              '</div>' +
-            '</li>',
+          template: _getDefaultTemplate(),
           link: function(scope, element, attrs, ctrl, transclude) {
             if (scope.message.compileContent) {
               var transcludedEl;
@@ -96,5 +85,22 @@
         };
       }
     ]);
+
+
+  function _getDefaultTemplate(customContent)
+  {
+    return ''+
+      '<li class="ng-toast__message {{message.additionalClasses}}">' +
+        '<div class="alert alert-{{message.className}}" ' +
+          'ng-class="{\'alert-dismissible\': message.dismissButton}">' +
+          '<button type="button" class="close" ' +
+            'ng-if="message.dismissButton" ' +
+            'ng-bind-html="message.dismissButtonHtml" ' +
+            'ng-click="!message.dismissOnClick && dismiss()">' +
+          '</button>' +
+          (customContent || '<span ng-if="!message.compileContent" ng-transclude></span>') +
+        '</div>' +
+      '</li>';
+  }
 
 })(window, window.angular);


### PR DESCRIPTION
Hi,
i'm using ngToast for some days, and i really missed this features. Once i saw (in #41) that you aren't gonna implement this, i decided to make it myself.

My commits aren't break anything just extending the existing functionality.

I don't have enough time to add the tests, maybe i'll do it next week.

So, now you can create a toast and assign a controller, ex:
```js
ngToast.create({
    template: '<button ng-click="vm.onButton()">Click me [{{vm.clicks}}]</button>',
    controller: function myController() {
        this.clicks = 0;
        this.onButton = function () {
            this.clicks++;
        };
    },
    controllerAs: 'vm',
    dismissOnClick: false,
    dismissButton: true,
});
```


Added options:
* **templateUrl** - *{string}*: The url of an html template file that will be used as the content of the toast. 
* **template** - {string}: Same as templateUrl, except this is an actual template string.
* **controller** - *{string|array|function}*: The controller to associate with this toast. 
* **controllerAs** - *{string}*: An alias to assign the controller to on the scope.