### PR TITLE
compileContent Update & Hold toast on mouse over

### DIFF
--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -82,27 +82,27 @@
 
             if (scope.message.dismissOnTimeout) {
 
-                $timeout(function() {
-                    scope.message.timedOut = true;
-                });
+                //$timeout(function() {
+                //    scope.message.timedOut = true;
+                //});
 
                 var dismisstimeout = $timeout(function () {
                     ngToast.dismiss(scope.message.id);
                 }, scope.message.timeout);
 
                 
-                element.mouseenter(function (event) {
-                    $timeout.cancel(dismisstimeout);
-                });
+                //element.mouseenter(function (event) {
+                //    $timeout.cancel(dismisstimeout);
+                //});
 
-                element.mouseleave(function (event) {
+                //element.mouseleave(function (event) {
 
-                    var timeout = scope.message.timedOut ? 500 : 2000;
+                //    var timeout = scope.message.timedOut ? 500 : 2000;
 
-                    dismisstimeout = $timeout(function () {
-                        ngToast.dismiss(scope.message.id);
-                    }, timeout);
-                });
+                //    dismisstimeout = $timeout(function () {
+                //        ngToast.dismiss(scope.message.id);
+                //    }, timeout);
+                //});
             }
 
             if (scope.message.dismissOnClick) {

--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -66,7 +66,9 @@
           link: function(scope, element, attrs, ctrl, transclude) {
             if (scope.message.compileContent) {
               var transcludedEl;
-
+              
+              var compileScope = scope.message.compileToScope || scope.$parent;
+              
               transclude(scope, function(clone) {
                 transcludedEl = clone;
                 element.children().append(transcludedEl);
@@ -74,7 +76,7 @@
 
               $timeout(function() {
                 $compile(transcludedEl.contents())
-                  (scope.$parent, function(compiledClone) {
+                  (compileScope, function(compiledClone) {
                     transcludedEl.replaceWith(compiledClone);
                   });
               }, 0);

--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -83,9 +83,28 @@
             }
 
             if (scope.message.dismissOnTimeout) {
-              $timeout(function() {
-                ngToast.dismiss(scope.message.id);
-              }, scope.message.timeout);
+
+                $timeout(function() {
+                    scope.message.timedOut = true;
+                });
+
+                var dismisstimeout = $timeout(function () {
+                    ngToast.dismiss(scope.message.id);
+                }, scope.message.timeout);
+
+                
+                element.mouseenter(function (event) {
+                    $timeout.cancel(dismisstimeout);
+                });
+
+                element.mouseleave(function (event) {
+
+                    var timeout = scope.message.timedOut ? 500 : 2000;
+
+                    dismisstimeout = $timeout(function () {
+                        ngToast.dismiss(scope.message.id);
+                    }, timeout);
+                });
             }
 
             if (scope.message.dismissOnClick) {

--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -67,8 +67,6 @@
             if (scope.message.compileContent) {
               var transcludedEl;
               
-              var compileScope = scope.message.compileToScope || scope.$parent;
-              
               transclude(scope, function(clone) {
                 transcludedEl = clone;
                 element.children().append(transcludedEl);
@@ -76,7 +74,7 @@
 
               $timeout(function() {
                 $compile(transcludedEl.contents())
-                  (compileScope, function(compiledClone) {
+                  (scope.message.compileToScope || scope.$parent, function(compiledClone) {
                     transcludedEl.replaceWith(compiledClone);
                   });
               }, 0);

--- a/src/scripts/provider.js
+++ b/src/scripts/provider.js
@@ -17,6 +17,7 @@
           dismissButtonHtml: '&times;',
           dismissOnClick: true,
           compileContent: false,
+          compileToScope: null,
           horizontalPosition: 'right', // right, center, left
           verticalPosition: 'top', // top, bottom,
           maxNumber: 0


### PR DESCRIPTION
This change addresses the issue of the compileContent property only able to compile for the "toast" directive's parent scope.  a compileToScope property is added to allow the compilation to any scope assigned to the property.

Add the capability to hold any toast on the screen my mousing over it.  Once mouse out if the timeout expired, a 0.5 second timeout is applied, else a 2 seconds timeout is applied.