### PR TITLE
fix bower dependency issue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ngToast",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "main": [
     "dist/ngToast.js",
     "dist/ngToast.css"
@@ -10,9 +10,9 @@
     "Levi Thomason (http://www.levithomason.com)"
   ],
   "dependencies": {
-    "angular": ">=1.2.15 <=1.4",
-    "angular-animate": ">=1.2.17 <=1.4",
-    "angular-sanitize": ">=1.2.15 <=1.4"
+    "angular": ">=1.2.15 < 1.5",
+    "angular-animate": ">=1.2.17 < 1.5",
+    "angular-sanitize": ">=1.2.15 < 1.5"
   },
   "devDependencies": {
     "bootstrap": "~3.3.2",


### PR DESCRIPTION
Sorry for the spam. Turns out saying <= 1.4 does not include 1.4.x, so i had to change it to < 1.5. I guess this requires another release of 1.5.5 for ngToast