### PR TITLE
Templates now installed into $templateCache, not defined in directive

### DIFF
--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -2,20 +2,42 @@
   'use strict';
 
   angular.module('ngToast.directives', ['ngToast.provider'])
+    .run(['$templateCache',
+      function($templateCache) {
+        $templateCache.put('ngToast/toast.html',
+          '<div class="ng-toast ng-toast--{{hPos}} ng-toast--{{vPos}} {{animation ? \'ng-toast--animate-\' + animation : \'\'}}">' +
+            '<ul class="ng-toast__list">' +
+              '<toast-message ng-repeat="message in messages" ' +
+                'message="message" count="message.count">' +
+                '<span ng-bind-html="message.content"></span>' +
+              '</toast-message>' +
+            '</ul>' +
+          '</div>');
+        $templateCache.put('ngToast/toastMessage.html',
+          '<li class="ng-toast__message {{message.additionalClasses}}"' +
+            'ng-mouseenter="onMouseEnter()"' +
+            'ng-mouseleave="onMouseLeave()">' +
+            '<div class="alert alert-{{message.className}}" ' +
+              'ng-class="{\'alert-dismissible\': message.dismissButton}">' +
+              '<button type="button" class="close" ' +
+                'ng-if="message.dismissButton" ' +
+                'ng-bind-html="message.dismissButtonHtml" ' +
+                'ng-click="!message.dismissOnClick && dismiss()">' +
+              '</button>' +
+              '<span ng-if="count" class="ng-toast__message__count">' +
+                '{{count + 1}}' +
+              '</span>' +
+              '<span ng-if="!message.compileContent" ng-transclude></span>' +
+            '</div>' +
+          '</li>');
+      }
+    ])
     .directive('toast', ['ngToast', '$templateCache', '$log',
       function(ngToast, $templateCache, $log) {
         return {
           replace: true,
           restrict: 'EA',
-          template:
-            '<div class="ng-toast ng-toast--{{hPos}} ng-toast--{{vPos}} {{animation ? \'ng-toast--animate-\' + animation : \'\'}}">' +
-              '<ul class="ng-toast__list">' +
-                '<toast-message ng-repeat="message in messages" ' +
-                  'message="message" count="message.count">' +
-                  '<span ng-bind-html="message.content"></span>' +
-                '</toast-message>' +
-              '</ul>' +
-            '</div>',
+          templateUrl: 'ngToast/toast.html',
           compile: function(tElem, tAttrs) {
             if (tAttrs.template) {
               var template = $templateCache.get(tAttrs.template);
@@ -52,23 +74,7 @@
               ngToast.dismiss($scope.message.id);
             };
           }],
-          template:
-            '<li class="ng-toast__message {{message.additionalClasses}}"' +
-              'ng-mouseenter="onMouseEnter()"' +
-              'ng-mouseleave="onMouseLeave()">' +
-              '<div class="alert alert-{{message.className}}" ' +
-                'ng-class="{\'alert-dismissible\': message.dismissButton}">' +
-                '<button type="button" class="close" ' +
-                  'ng-if="message.dismissButton" ' +
-                  'ng-bind-html="message.dismissButtonHtml" ' +
-                  'ng-click="!message.dismissOnClick && dismiss()">' +
-                '</button>' +
-                '<span ng-if="count" class="ng-toast__message__count">' +
-                  '{{count + 1}}' +
-                '</span>' +
-                '<span ng-if="!message.compileContent" ng-transclude></span>' +
-              '</div>' +
-            '</li>',
+          templateUrl: 'ngToast/toastMessage.html',
           link: function(scope, element, attrs, ctrl, transclude) {
             element.attr('data-message-id', scope.message.id);
 


### PR DESCRIPTION
We have a use case where we want to override the templates being
used, but have no ability to do so when they're inlined in the
directive.  By using the $templateCache, we can override them, as
well as still ensure the directives work as expected.

--
I built and ran the tests and everything still passes.  I didn't commit the dist code, as I figured it'd be something you should do.  If you'd rather me include it, I can do so.